### PR TITLE
recipe: use go-licenses dependency instead of installing it manually

### DIFF
--- a/recipe/build_library_licenses.sh
+++ b/recipe/build_library_licenses.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -e
 
-go get github.com/google/go-licenses
-
 export LIBRARY_LICENSES_PATH="$RECIPE_DIR/library_licenses/"
 
 # Clone v0.16.1.
 pushd $SRC_DIR
 rm -rf $LIBRARY_LICENSES_PATH
-${PREFIX}/bin/go-licenses save "github.com/tilt-dev/tilt/cmd/tilt" --save_path=$LIBRARY_LICENSES_PATH
+go-licenses save "github.com/tilt-dev/tilt/cmd/tilt" --save_path=$LIBRARY_LICENSES_PATH
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   build:
     - {{ compiler('go') }}
     - {{ compiler('cxx') }}
+    - go-licenses
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/go-licenses:

bf465a04d952150a37b772c1c340094ccba76944 (2021-01-29 14:57:53 -0500)
recipe: use go-licenses dependency instead of installing it manually
I checked other autogenerated Go projects (like
https://github.com/conda-forge/podman-feedstock/blob/master/recipe/meta.yaml)
and this seems be what they do. But I don't totally understand why conda-smithy
rerender doesn't fix this automatically.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics